### PR TITLE
fix(lint): resolve golangci-lint v2.5.0 issues

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -98,8 +98,9 @@ func (s *Server) Start() error {
 	addr := fmt.Sprintf("%s:%d", s.config.Server.Host, s.config.Server.Port)
 
 	s.server = &http.Server{
-		Addr:    addr,
-		Handler: s.router,
+		Addr:              addr,
+		Handler:           s.router,
+		ReadHeaderTimeout: 30 * time.Second,
 	}
 
 	return s.server.ListenAndServe()


### PR DESCRIPTION
Fixes linting issues introduced by golangci-lint v2.5.0:

- Add ReadHeaderTimeout to http.Server to prevent Slowloris attacks (gosec G112)

All linting issues resolved, 0 issues remaining.