### PR TITLE
feat(renovate): use feat: commit messages for dependency updates

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -48,6 +48,14 @@
         'gomodTidy',
       ],
     },
+    {
+      matchManagers: [
+        'gomod',
+      ],
+      commitMessagePrefix: 'feat:',
+      commitMessageAction: 'update',
+      commitMessageTopic: 'dependencies',
+    },
   ],
   customManagers: [
     {


### PR DESCRIPTION
## Summary
Update renovate configuration to use `feat:` commit messages for Go module dependency updates, enabling automatic releases for dependency changes.

## Changes
- Added new package rule to renovate.json5 for gomod manager
- Uses `feat:` prefix for dependency update commits
- This will trigger release-please to create releases for dependency updates
- Enables frequent small releases for dependency changes

## Why This Change?
- Dependency updates are currently using `chore(deps):` which doesn't trigger releases
- Using `feat:` will make release-please treat dependency updates as user-facing changes
- Provides more frequent releases for dependency updates
- Follows semantic versioning principles

## Testing
- No functional changes to the application
- Only affects commit message format for future dependency updates
- Release-please will now create releases for dependency updates