### PR TITLE
fix: align MQTTConnectionErrors label with registered name

### DIFF
--- a/internal/collectors/mqtt_collector.go
+++ b/internal/collectors/mqtt_collector.go
@@ -105,8 +105,8 @@ func (mc *MQTTCollector) run(ctx context.Context) {
 				"broker": mc.config.MQTT.Broker,
 			}).Set(0)
 			mc.metrics.MQTTConnectionErrors.With(prometheus.Labels{
-				"broker": mc.config.MQTT.Broker,
-				"reason": "connect",
+				"broker":     mc.config.MQTT.Broker,
+				"error_type": "connect",
 			}).Inc()
 
 			select {
@@ -151,8 +151,8 @@ func (mc *MQTTCollector) run(ctx context.Context) {
 			}
 
 			mc.metrics.MQTTConnectionErrors.With(prometheus.Labels{
-				"broker": mc.config.MQTT.Broker,
-				"reason": "subscribe",
+				"broker":     mc.config.MQTT.Broker,
+				"error_type": "subscribe",
 			}).Inc()
 
 			// Disconnect and retry
@@ -409,8 +409,8 @@ func (mc *MQTTCollector) onConnectionLost(client MQTT.Client, err error) {
 		"broker": mc.config.MQTT.Broker,
 	}).Set(0)
 	mc.metrics.MQTTConnectionErrors.With(prometheus.Labels{
-		"broker": mc.config.MQTT.Broker,
-		"reason": "connection_lost",
+		"broker":     mc.config.MQTT.Broker,
+		"error_type": "connection_lost",
 	}).Inc()
 	mc.metrics.MQTTReconnectsTotal.With(prometheus.Labels{
 		"broker": mc.config.MQTT.Broker,


### PR DESCRIPTION
## Summary
- The metric \`mqtt_connection_errors_total\` is registered in \`internal/metrics/mqtt_registry.go:70-76\` with labels \`[broker, error_type]\`, but three call sites in \`mqtt_collector.go\` (lines 107, 153, 411) were using \`[broker, reason]\`.
- \`prometheus.Labels.With()\` panics on label mismatch, so the very first connect failure, subscribe failure, or connection-lost event would crash the exporter.
- This PR renames the call-site label key from \`reason\` to \`error_type\` at all three sites.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`
- [ ] Trigger a connection error (wrong broker) and confirm the exporter no longer panics and \`mqtt_connection_errors_total{error_type="connect"}\` appears.