### PR TITLE
test: add regression test for MQTTConnectionErrors labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/d0ugal/promexporter v1.14.51
 	github.com/eclipse/paho.mqtt.golang v1.5.1
 	github.com/prometheus/client_golang v1.23.2
+	github.com/stretchr/testify v1.11.1
 	go.opentelemetry.io/otel v1.43.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -20,6 +21,7 @@ require (
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudwego/base64x v0.1.7 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/gin-gonic/gin v1.12.0 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.20.1 // indirect

--- a/internal/collectors/mqtt_collector_test.go
+++ b/internal/collectors/mqtt_collector_test.go
@@ -1,0 +1,34 @@
+package collectors
+
+import (
+	"testing"
+
+	"github.com/d0ugal/mqtt-exporter/internal/metrics"
+	promexporter_metrics "github.com/d0ugal/promexporter/metrics"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestMQTTConnectionErrors_LabelsMatchRegistry guards against the label-name
+// mismatch between the registry definition (broker, error_type) and the call
+// sites in run() / onConnectionLost. If the labels drift again,
+// prometheus.Labels.With() panics here.
+func TestMQTTConnectionErrors_LabelsMatchRegistry(t *testing.T) {
+	baseRegistry := promexporter_metrics.NewRegistry("mqtt_exporter_info_test")
+	mqttMetrics := metrics.NewMQTTRegistry(baseRegistry)
+
+	assert.NotPanics(t, func() {
+		mqttMetrics.MQTTConnectionErrors.With(prometheus.Labels{
+			"broker":     "tcp://localhost:1883",
+			"error_type": "connect",
+		}).Inc()
+		mqttMetrics.MQTTConnectionErrors.With(prometheus.Labels{
+			"broker":     "tcp://localhost:1883",
+			"error_type": "subscribe",
+		}).Inc()
+		mqttMetrics.MQTTConnectionErrors.With(prometheus.Labels{
+			"broker":     "tcp://localhost:1883",
+			"error_type": "connection_lost",
+		}).Inc()
+	})
+}


### PR DESCRIPTION
## Summary
Follow-up to #650. Adds a regression test that constructs the registry and exercises every call-site of \`MQTTConnectionErrors\` (\`error_type=connect\`, \`subscribe\`, \`connection_lost\`). If the labels ever drift again from the registered \`(broker, error_type)\` dimension, \`prometheus.Labels.With()\` will panic in this test instead of in production.

## Test plan
- [x] \`go test ./internal/collectors/...\` passes