### PR TITLE
fix(security): store broker password as SensitiveString

### DIFF
--- a/internal/collectors/mqtt_collector.go
+++ b/internal/collectors/mqtt_collector.go
@@ -234,7 +234,7 @@ func (mc *MQTTCollector) connect(ctx context.Context) error {
 
 	if mc.config.MQTT.Username != "" {
 		opts.SetUsername(mc.config.MQTT.Username)
-		opts.SetPassword(mc.config.MQTT.Password)
+		opts.SetPassword(mc.config.MQTT.Password.Value())
 	}
 
 	opts.SetCleanSession(mc.config.MQTT.CleanSession)

--- a/internal/collectors/mqtt_collector_test.go
+++ b/internal/collectors/mqtt_collector_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/d0ugal/mqtt-exporter/internal/metrics"
+	promexporter_config "github.com/d0ugal/promexporter/config"
 	promexporter_metrics "github.com/d0ugal/promexporter/metrics"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
@@ -31,4 +32,26 @@ func TestMQTTConnectionErrors_LabelsMatchRegistry(t *testing.T) {
 			"error_type": "connection_lost",
 		}).Inc()
 	})
+}
+
+// TestMQTTPassword_RedactsInString locks in that the broker password is
+// stored as a SensitiveString whose String() returns "[REDACTED]" rather
+// than the raw value. Without this, anything that prints the config would
+// leak the broker password.
+func TestMQTTPassword_RedactsInString(t *testing.T) {
+	const secret = "supersecretmqttpw"
+
+	pw := promexporter_config.NewSensitiveString(secret)
+
+	if pw.Value() != secret {
+		t.Fatalf("Value() did not round-trip: want %q, got %q", secret, pw.Value())
+	}
+
+	if got := pw.String(); got == secret {
+		t.Fatalf("String() leaked the raw password: %q", got)
+	}
+
+	if got := pw.String(); got != "[REDACTED]" {
+		t.Fatalf("String() unexpected: want [REDACTED], got %q", got)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,15 +21,15 @@ type Config struct {
 }
 
 type MQTTConfig struct {
-	Broker         string   `yaml:"broker"`
-	ClientID       string   `yaml:"client_id"`
-	Username       string   `yaml:"username"`
-	Password       string   `yaml:"password"`
-	Topics         []string `yaml:"topics"`
-	QoS            int      `yaml:"qos"`
-	CleanSession   bool     `yaml:"clean_session"`
-	KeepAlive      Duration `yaml:"keep_alive"`
-	ConnectTimeout Duration `yaml:"connect_timeout"`
+	Broker         string                              `yaml:"broker"`
+	ClientID       string                              `yaml:"client_id"`
+	Username       string                              `yaml:"username"`
+	Password       promexporter_config.SensitiveString `yaml:"password"`
+	Topics         []string                            `yaml:"topics"`
+	QoS            int                                 `yaml:"qos"`
+	CleanSession   bool                                `yaml:"clean_session"`
+	KeepAlive      Duration                            `yaml:"keep_alive"`
+	ConnectTimeout Duration                            `yaml:"connect_timeout"`
 }
 
 // LoadConfig loads configuration with priority: env vars > yaml file > defaults.
@@ -104,7 +104,7 @@ func applyEnvVars(cfg *Config) {
 	}
 
 	if password := os.Getenv("MQTT_EXPORTER_MQTT_PASSWORD"); password != "" {
-		cfg.MQTT.Password = password
+		cfg.MQTT.Password = promexporter_config.NewSensitiveString(password)
 	}
 
 	if topicsStr := os.Getenv("MQTT_EXPORTER_MQTT_TOPICS"); topicsStr != "" {


### PR DESCRIPTION
## Summary
\`MQTT.Password\` was a plain \`string\`, so any code path that printed the config (slog with \`%v\`, error wrapping, dashboard rendering) would leak the broker password into logs.

Switch to \`promexporter/config.SensitiveString\`, which redacts on \`String()\` and \`MarshalJSON()\`. The env-var setter uses \`NewSensitiveString\`; the collector calls \`.Value()\` when passing the raw password to paho's \`SetPassword\`.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./internal/collectors/...\` — new \`TestMQTTPassword_RedactsInString\` asserts the wrapped password's \`String()\` emits \`[REDACTED]\`.